### PR TITLE
Specify sans-serif as the generic font family:

### DIFF
--- a/tab_switcher/switcher.css
+++ b/tab_switcher/switcher.css
@@ -7,7 +7,7 @@ body {
 	margin: 0;
 	display: flex;
 	flex-direction: column;
-	font-family: Calibri;
+	font-family: Calibri, sans-serif;
 }
 
 #search_input {


### PR DESCRIPTION
Calibri might not be available on all installations,
and the FF will default to "serif" font family.