### PR TITLE
add support for emacs/mac style previous/next line navigation

### DIFF
--- a/tab_switcher/switcher.js
+++ b/tab_switcher/switcher.js
@@ -86,7 +86,14 @@ $(window).on('keydown', event => {
 	} else if (key === 'ArrowUp') {
 		setSelectedString(getNextPageUpIndex(1));
 		event.preventDefault();
-	} else if (key === 'PageDown') {
+	} else if (event.ctrlKey && key == 'n') {
+		setSelectedString(getNextPageDownIndex(1));
+		event.preventDefault();
+	} else if (event.ctrlKey && key == 'p') {
+		setSelectedString(getNextPageUpIndex(1));
+		event.preventDefault();
+	}
+	else if (key === 'PageDown') {
 		setSelectedString(getNextPageDownIndex(13));
 		event.preventDefault();
 	} else if (key === 'PageUp') {


### PR DESCRIPTION
This PR adds support for ctrl-n and ctrl-p navigation to move down and up, respectively, in the tab-switcher. 

Not sure if this is desired in the extension, but I figured I'd PR it anyway. If it's a little too obscure for the mainstream, I'll just use my fork 😄 