### PR TITLE
Allow a unique keyword to be assigned to a tab.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -39,7 +39,7 @@
 
 	"name" : "Fast Tab Switcher",
 
-	"permissions" : ["tabs"],
+	"permissions" : ["tabs", "sessions"],
 
 	"version" : "2.6.0"
 }

--- a/tab_switcher/switcher.css
+++ b/tab_switcher/switcher.css
@@ -52,3 +52,7 @@ body {
 	background-color: #0A84FF;
 	border-color: #0A84FF;
 }
+
+#keyword_label {
+	width: 100vw;
+}

--- a/tab_switcher/switcher.html
+++ b/tab_switcher/switcher.html
@@ -30,6 +30,8 @@
 	</table>
 </div>
 
+<label id="keyword_label" hidden>Enter keyword to assign to this tab</label>
+
 <script src="switcher.js"></script>
 
 </body>


### PR DESCRIPTION
This was inspired by keyword bookmarks, which allow you to type a keyword into the address bar.

To assign a keyword to the current tab, you type the = character into the text box, then type the keyword to assign and press enter. If you then later type this exact keyword into the text box, this tab will show at the top of the results such that pressing enter will switch to this tab. Note that the keyword must be an exact match. This allows you to very quickly switch to frequently used tabs.

As an example, to switch to my personal mail, I can just do control+space, pm, enter.