### PR TITLE
Improve "close tab" in OSX by catching Backspace key

### DIFF
--- a/tab_switcher/switcher.js
+++ b/tab_switcher/switcher.js
@@ -178,8 +178,15 @@ $(window).on('keydown', event => {
 		} else {
 			activateTab();
 		}
-	} else if (event.ctrlKey && (key === 'Delete' || key === 'Backspace')) {
-		/* In OSX, key = `Backspace` when pressing Delete */
+  } else if ((event.ctrlKey && key === 'Delete') ||
+             (event.metaKey && key === 'Backspace')) {
+    /*
+    Windows -- ideal combo: Ctrl+Delete -- alternate: Windows+Backspace
+    (`meta` is the Windows key)
+
+    OSX -- ideal combo: Cmd+Delete -- alternate: Fn+Ctrl+Delete
+    (Delete key is treated as `Backspace` unless Fn modifier is pressed)
+    */
 		closeTab();
 		event.preventDefault();
 	}

--- a/tab_switcher/switcher.js
+++ b/tab_switcher/switcher.js
@@ -178,7 +178,8 @@ $(window).on('keydown', event => {
 		} else {
 			activateTab();
 		}
-	} else if (event.ctrlKey && key === 'Delete') {
+	} else if (event.ctrlKey && (key === 'Delete' || key === 'Backspace')) {
+		/* In OSX, key = `Backspace` when pressing Delete */
 		closeTab();
 		event.preventDefault();
 	}


### PR DESCRIPTION
Make `Ctrl+Delete` work instead of needing `Fn+Ctrl+Delete` on OSX.

In OSX, without the `Fn` modifier, the `delete` key is trapped as "Backspace".

(The older key combination will continue working)



