### PR TITLE
Switch from table to flexbox

### DIFF
--- a/tab_switcher/switcher.css
+++ b/tab_switcher/switcher.css
@@ -15,39 +15,69 @@ body {
 	font-size: large;
 }
 
-#tabs_table__container {
+#tabs_container {
 	flex: 1;
-	overflow-y: scroll;
-}
-
-#tabs_table {
+	display: flex;
+	flex-direction: column;
 	width: 100%;
 	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-	table-layout: fixed;
-	border: 0;
-	font-size: 14px;
 }
 
-#tabs_table td {
-	overflow: hidden;
-	text-overflow: ellipsis;
-	padding-top: 4px;
-	padding-bottom: 4px;
+.tabs_header {
+	display: flex;
+	width: 100%;
+	font-weight: bold;
+	background-color: #f0f0f0;
+	border-bottom: 1px solid #ddd;
+	padding: 4px 0;
+}
+
+#tabs_list {
+	flex: 1;
+	overflow-y: auto;
+	width: 100%;
+}
+
+.tab_item {
+	display: flex;
+	width: 100%;
+	padding: 4px 0;
 	cursor: default;
 	-moz-user-select: none;
+	border-bottom: 1px solid #f0f0f0;
 }
 
-.tabs_table__column_icon {
+/* Fixed column widths - mirroring table behavior */
+.tab_icon, .tab_icon_header {
 	width: 18px;
+	min-width: 18px;
+	max-width: 18px;
+	flex-shrink: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
-.tabs_table__column_title {
+.tab_title, .tab_title_header {
 	width: 300px;
+	min-width: 300px;
+	max-width: 300px;
+	flex-shrink: 0;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	padding: 0 8px;
 }
 
-.tabs_table__selected {
+.tab_url, .tab_url_header {
+	flex: 1;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	padding: 0 8px;
+}
+
+.selected {
 	color: white;
 	background-color: #0A84FF;
 	border-color: #0A84FF;

--- a/tab_switcher/switcher.html
+++ b/tab_switcher/switcher.html
@@ -9,23 +9,15 @@
 
 <input id="search_input"></input>
 
-<div id="tabs_table__container">
-	<table id="tabs_table" cellspacing="0">
-		<col class="tabs_table__column_icon">
-		<col class="tabs_table__column_title">
-		<col class="tabs_table__column_url">
-
-		<thead>
-			<tr>
-				<th></th>
-				<th>Title</th>
-				<th>Url</th>
-			</tr>
-		</thead>
-
-		<tbody>
-		</tbody>
-	</table>
+<div id="tabs_container">
+	<div class="tabs_header">
+		<div class="tab_icon_header"></div>
+		<div class="tab_title_header">Title</div>
+		<div class="tab_url_header">Url</div>
+	</div>
+	<div id="tabs_list">
+		<!-- Tab items will be inserted here -->
+	</div>
 </div>
 
 <label id="keyword_label" hidden>Enter keyword to assign to this tab</label>

--- a/tab_switcher/switcher.js
+++ b/tab_switcher/switcher.js
@@ -86,44 +86,48 @@ function updateVisibleTabs(query, preserveSelectedTabIndex) {
 		}
 	}
 
-	// Update the body of the table with filtered tabs
-	const tbody = document.querySelector('#tabs_table tbody');
-	tbody.innerHTML = '';
+	// Update the tabs list with filtered tabs
+	const tabsList = document.getElementById('tabs_list');
+	tabsList.innerHTML = '';
 
 	const fragment = document.createDocumentFragment();
 
 	tabs.forEach((tab, tabIndex) => {
-		const tr = document.createElement('tr');
+		const tabItem = document.createElement('div');
+		tabItem.className = 'tab_item';
 
-		// First column (favicon)
-		const tdIcon = document.createElement('td');
+		// Icon section
+		const iconDiv = document.createElement('div');
+		iconDiv.className = 'tab_icon';
 		if (tab.favIconUrl) {
 			const img = document.createElement('img');
 			img.width = 16;
 			img.height = 16;
 			img.src = !tab.incognito ? tab.favIconUrl : '/icons/mask16.svg';
-			tdIcon.appendChild(img);
+			iconDiv.appendChild(img);
 		}
-		tr.appendChild(tdIcon);
+		tabItem.appendChild(iconDiv);
 
-		// Second column (title)
-		const tdTitle = document.createElement('td');
-		tdTitle.textContent = tab.title;
-		tr.appendChild(tdTitle);
+		// Title section
+		const titleDiv = document.createElement('div');
+		titleDiv.className = 'tab_title';
+		titleDiv.textContent = tab.title;
+		tabItem.appendChild(titleDiv);
 
-		// Third column (url)
-		const tdUrl = document.createElement('td');
-		tdUrl.textContent = tab.url;
-		tr.appendChild(tdUrl);
+		// URL section
+		const urlDiv = document.createElement('div');
+		urlDiv.className = 'tab_url';
+		urlDiv.textContent = tab.url;
+		tabItem.appendChild(urlDiv);
 
 		// Store data attributes
-		tr.dataset.index = tabIndex;
-		tr.dataset.tabId = tab.id;
+		tabItem.dataset.index = tabIndex;
+		tabItem.dataset.tabId = tab.id;
 
-		fragment.appendChild(tr);
+		fragment.appendChild(tabItem);
 	});
 
-	tbody.appendChild(fragment);
+	tabsList.appendChild(fragment);
 
 	// Highlight the selected tab
 	setSelectedString(tabIndex);
@@ -140,7 +144,7 @@ async function beginSetTabKeyword() {
 	isSettingKeyword = true;
 	const tabs = await browser.tabs.query({active: true, currentWindow: true});
 	const keyword = await browser.sessions.getTabValue(tabs[0].id, "keyword");
-	document.getElementById("tabs_table__container").style.display = "none";
+	document.getElementById("tabs_container").style.display = "none";
 	document.getElementById("keyword_label").style.display = "block";
 
 	const searchInput = document.getElementById("search_input");
@@ -263,18 +267,18 @@ function enableQuickSwitch() {
 }
 
 function setSelectedString(index) {
-	const table = document.querySelector('#tabs_table tbody');
+	const tabsList = document.getElementById('tabs_list');
 
-	const newSelected = table.querySelector(`tr:nth-child(${index+1})`);
+	const newSelected = tabsList.querySelector(`.tab_item:nth-child(${index+1})`);
 	if (!newSelected || index < 0) {
 		return;
 	}
 
 	if (selectedString) {
-		selectedString.classList.remove('tabs_table__selected');
+		selectedString.classList.remove('selected');
 	}
 
-	newSelected.classList.add('tabs_table__selected');
+	newSelected.classList.add('selected');
 
 	selectedString = newSelected;
 
@@ -282,27 +286,15 @@ function setSelectedString(index) {
 }
 
 function scrollToSelection() {
-	if (!selectedString) {
-		return;
-	}
+  if (!selectedString) {
+    return;
+  }
 
-	const scrollPadding = 20;
-
-	const tableContainer = document.getElementById('tabs_table__container');
-	const stringOffset = selectedString.offsetTop;
-	const scrollMax = stringOffset - scrollPadding;
-	const scrollMin = stringOffset
-		+ selectedString.offsetHeight - tableContainer.offsetHeight + scrollPadding;
-
-	if (scrollMax < scrollMin) {
-		// Resetting scroll since there is no enough space
-		tableContainer.scrollTop = 0;
-		return;
-	}
-
-	const scrollValue = Math.max(0, scrollMin,
-		Math.min(scrollMax, tableContainer.scrollTop));
-	tableContainer.scrollTop = scrollValue;
+  selectedString.scrollIntoView({
+    behavior: 'auto',
+    block: 'nearest',
+    inline: 'nearest'
+  });
 }
 
 /**
@@ -333,7 +325,7 @@ function getNextPageDownIndex(pageSize) {
 }
 
 function getTableSize() {
-	return document.querySelectorAll('#tabs_table tbody tr').length;
+	return document.querySelectorAll('#tabs_list .tab_item').length;
 }
 
 /**
@@ -395,18 +387,18 @@ function getSelectedTabId() {
 }
 
 function setupTableEventListeners() {
-	const tbody = document.querySelector('#tabs_table tbody');
+	const tabsList = document.getElementById('tabs_list');
 
-	tbody.addEventListener('click', (event) => {
-		const tr = event.target.closest('tr');
-		if (tr) {
-			setSelectedString(parseInt(tr.dataset.index));
+	tabsList.addEventListener('click', (event) => {
+		const tabItem = event.target.closest('.tab_item');
+		if (tabItem) {
+			setSelectedString(parseInt(tabItem.dataset.index));
 		}
 	});
 
-	tbody.addEventListener('dblclick', (event) => {
-		const tr = event.target.closest('tr');
-		if (tr) {
+	tabsList.addEventListener('dblclick', (event) => {
+		const tabItem = event.target.closest('.tab_item');
+		if (tabItem) {
 			activateTab();
 		}
 	});


### PR DESCRIPTION
As mentioned in <https://github.com/tapapax/firefox-fts/pull/52#issuecomment-2920456227>. The underlying idea is that flexbox rendering is supposed to be more highly optimized than table, but that doesn't show as convincingly as I'd hoped.

The performance improvement isn't clearly noticeable like #52, and it's hard to even measure. Repeated measurements seem to suggest the current code with `<table>` sits more around 40-50 ms (3 frames) to open while this code with `flex` takes 30-40 ms (2 frames) with 286 tabs, but there's quite a bit of variability. So this change probably isn't worth it for performance reasons, but I figured it'd be a waste not to show it off. I'm not immediately sure if it has other merits. For the most part it's neither obviously better nor worse. It seems to be a tiny bit faster, but `<table>` automatically acts like a table.

PS Earlier I was having trouble getting the scrolling completely right, but it turns out the scrollIntoView() method can do it all for you. This may be a nice simplification regardless of the table vs flexbox thing.

```js
function scrollToSelection() {
  if (!selectedString) {
    return;
  }

  selectedString.scrollIntoView({
    behavior: 'auto',
    block: 'nearest',
    inline: 'nearest'
  });
}
```